### PR TITLE
Fix issue with crashing on import with .net 4.5

### DIFF
--- a/SIMSBulkImport/UI/ImportWindow.xaml.cs
+++ b/SIMSBulkImport/UI/ImportWindow.xaml.cs
@@ -104,8 +104,15 @@ namespace Matt40k.SIMSBulkImport
         {
             logger.Log(LogLevel.Trace, "Trace:: Matt40k.SIMSBulkImport.ImportWindow.bw_ProgressChanged()");
             Status.Content = "Querying SIMS database - " + e.ProgressPercentage + "%";
-            dataGrid.DataContext = dataGridTable;
-            dataGrid.Items.Refresh();
+            // Refreshing the dataGrid causes a crash in .net 4.5, so don't refresh. Version number for 4.5 
+            // is actually 4.0.30319.17626 for some reason
+            // http://stackoverflow.com/questions/12971881/how-to-reliably-detect-the-actual-net-4-5-version-installed
+            Version dotNetVersion = System.Environment.Version;
+            if (dotNetVersion.Major <= 4 && dotNetVersion.Minor <= 0 && dotNetVersion.Build <= 30319 && dotNetVersion.Revision < 17626)
+            {
+                dataGrid.DataContext = dataGridTable;
+                dataGrid.Items.Refresh();
+            }   
         }
 
         private void bw_DoWork(object sender, DoWorkEventArgs e)


### PR DESCRIPTION
Fix for the crash on importing. It's down to change in the threading model in .net 4.5. Resolution is not to update the data grid if running under .net 4.5. I couldn't manage to get it to work.